### PR TITLE
Pin the activesupport gem above version 4.1.11 for dependabot alert

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,8 @@ source "https://rubygems.org"
 
 ruby '2.7.4'
 
-gem "github-pages", group: :jekyll_plugins
+gem "github-pages", ">= 223", group: :jekyll_plugins
+gem "activesupport", ">= 4.1.11"
 
 gem "tzinfo-data"
 
@@ -15,4 +16,5 @@ group :jekyll_plugins do
   gem "jemoji"
   gem "jekyll-include-cache"
   gem "jekyll-algolia"
+  gem "jekyll-github-metadata", ">= 2.13.0"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,12 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (3.2.22.5)
-      i18n (~> 0.6, >= 0.6.4)
-      multi_json (~> 1.0)
+    activesupport (6.0.4.4)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+      zeitwerk (~> 2.2, >= 2.2.2)
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     algolia_html_extractor (2.6.4)
@@ -20,9 +23,7 @@ GEM
     commonmarker (0.17.13)
       ruby-enum (~> 0.5)
     concurrent-ruby (1.1.9)
-    date (3.2.2)
-    dnsruby (1.61.8)
-      net-ftp
+    dnsruby (1.61.9)
       simpleidn (~> 0.1)
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
@@ -116,7 +117,6 @@ GEM
     httpclient (2.8.3)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
-    io-wait (0.2.1)
     jekyll (3.9.0)
       addressable (~> 2.4)
       colorator (~> 1.0)
@@ -240,7 +240,7 @@ GEM
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
     liquid (4.0.3)
-    listen (3.7.0)
+    listen (3.7.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.3.6)
@@ -249,18 +249,12 @@ GEM
       jekyll (>= 3.5, < 5.0)
       jekyll-feed (~> 0.9)
       jekyll-seo-tag (~> 2.1)
-    multi_json (1.15.0)
+    minitest (5.15.0)
     multipart-post (2.1.1)
-    net-ftp (0.1.3)
-      net-protocol
-      time
-    net-protocol (0.1.2)
-      io-wait
-      timeout
-    nokogiri (1.13.0)
+    nokogiri (1.13.1)
       mini_portile2 (~> 2.7.0)
       racc (~> 1.4)
-    octokit (4.21.0)
+    octokit (4.22.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
     pathutil (0.16.2)
@@ -290,13 +284,11 @@ GEM
       unf (~> 0.1.4)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
-    time (0.2.0)
-      date
-    timeout (0.2.0)
+    thread_safe (0.3.6)
     typhoeus (1.4.0)
       ethon (>= 0.9.0)
-    tzinfo (2.0.4)
-      concurrent-ruby (~> 1.0)
+    tzinfo (1.2.9)
+      thread_safe (~> 0.1)
     tzinfo-data (1.2021.5)
       tzinfo (>= 1.0.0)
     unf (0.1.4)
@@ -304,15 +296,18 @@ GEM
     unf_ext (0.0.8)
     unicode-display_width (1.8.0)
     verbal_expressions (0.1.5)
+    zeitwerk (2.5.3)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  github-pages
+  activesupport (>= 4.1.11)
+  github-pages (>= 223)
   jekyll-algolia
   jekyll-feed
   jekyll-gist
+  jekyll-github-metadata (>= 2.13.0)
   jekyll-include-cache
   jekyll-paginate
   jekyll-sitemap


### PR DESCRIPTION
Details
CVE-2015-3227
moderate severity
Vulnerable versions: < 4.1.11
Patched version: 4.1.11