### PR TITLE
Add explicit ChatGPT reference to AI code-gen instructions

### DIFF
--- a/_pages/mobile-interview-project.md
+++ b/_pages/mobile-interview-project.md
@@ -186,9 +186,9 @@ Definitely! Please utilize as many Google searches and Stack Overflow searches a
 
 That being said, please do not bulk copy and paste large sections of code from 3rd party sources, as this would defeat the purpose of the evaluation. If you do copy in code, please note as such in your README.
 
- * Q) **Can I use GitHub Copilot or other AI code generation tools?**
+ * Q) **Can I use GitHub Copilot, ChatGPT, or other AI code generation tools?**
 
-No. We don't use GitHub Copilot or other AI code generation tools at Block, and we want this project to reflect the same tools and techniques that you would use on the job.
+No. We don't use GitHub Copilot, ChatGPT, or other AI tools for code generation at Block, and we want this project to reflect the same tools and techniques that you would use on the job.
 
  * Q) **Can I utilize code I’ve written for my personal / side projects?**
 


### PR DESCRIPTION
Proposal for explicit mention of ChatGPT as disallowed for AI code generation. This aims to remove vagueness in the instructions as ChatGPT can be used both as a general resource and for substantial code generation.

Per suggestion in conversation here: https://square.slack.com/archives/CKCLTU4BA/p1685663597738409